### PR TITLE
CRUD posts for a given thread

### DIFF
--- a/apps/mock_forum/lib/mock_forum.ex
+++ b/apps/mock_forum/lib/mock_forum.ex
@@ -15,7 +15,7 @@ defmodule MockForum do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
-      alias MockForum.{Repo, User, Subject, Thread}
+      alias MockForum.{Repo, User, Subject, Thread, Post}
     end
   end
 

--- a/apps/mock_forum/lib/mock_forum/commands/post_commands.ex
+++ b/apps/mock_forum/lib/mock_forum/commands/post_commands.ex
@@ -1,0 +1,14 @@
+defmodule MockForum.Commands.PostCommands do
+    @moduledoc """
+        Commands used to create forum threads that are assoicated with post hread parent
+    """
+    use MockForum, :commands
+    use MockForum.Commands.CrudCommands, 
+        record_schema:  %Post{}, 
+        record_type: Post, 
+        associations: []
+
+    def create(thread, thread_params) do
+        thread |> build_assoc(:posts) |> changeset(thread_params) |> Repo.insert
+    end
+end

--- a/apps/mock_forum/lib/mock_forum/commands/thread_commands.ex
+++ b/apps/mock_forum/lib/mock_forum/commands/thread_commands.ex
@@ -6,7 +6,7 @@ defmodule MockForum.Commands.ThreadCommands do
     use MockForum.Commands.CrudCommands, 
         record_schema:  %Thread{}, 
         record_type: Thread, 
-        associations: []
+        associations: [:posts]
 
     def create(subject, thread_params) do
         subject |> build_assoc(:threads) |> changeset(thread_params) |> Repo.insert

--- a/apps/mock_forum/lib/mock_forum/schema/post.ex
+++ b/apps/mock_forum/lib/mock_forum/schema/post.ex
@@ -1,0 +1,19 @@
+defmodule MockForum.Post do
+    @moduledoc false
+
+    use MockForum, :model
+
+    schema "posts" do
+        belongs_to :thread, MockForum.Thread
+        field :message, :string
+
+        timestamps()
+    end
+
+    def changeset(struct, params \\ %{}) do
+        struct
+        |> cast(params, [:message, :thread_id])
+        |> cast_assoc(:thread)
+        |> validate_required([:message])
+    end
+end

--- a/apps/mock_forum/lib/mock_forum/schema/thread.ex
+++ b/apps/mock_forum/lib/mock_forum/schema/thread.ex
@@ -7,6 +7,8 @@ defmodule MockForum.Thread do
         belongs_to :subject, MockForum.Subject
         field :title, :string
 
+        has_many :posts, MockForum.Post, on_delete: :delete_all 
+
         timestamps()
     end
 

--- a/apps/mock_forum/priv/repo/migrations/20170618143415_create_posts.exs
+++ b/apps/mock_forum/priv/repo/migrations/20170618143415_create_posts.exs
@@ -1,0 +1,12 @@
+defmodule MockForum.Repo.Migrations.CreatePosts do
+  use Ecto.Migration
+
+  def change do
+    create table(:posts) do
+      add :thread_id, references(:threads)
+      add :message, :string
+
+      timestamps()
+    end
+  end
+end

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/post_controller.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/post_controller.ex
@@ -1,0 +1,63 @@
+defmodule MockForum.Web.PostController do
+    @moduledoc """
+        Access point for CRUDing posts
+    """
+
+    use MockForum.Web, :controller
+    
+    alias MockForum.Commands.{ThreadCommands, PostCommands}
+
+    def index(conn, %{"thread_id" => thread_id}) do
+        thread = ThreadCommands.find(thread_id, :preload)
+        posts  = thread.posts
+        render conn, "index.html", thread: thread, posts: posts
+    end
+
+    def new(conn, %{"thread_id" => thread_id}) do
+        changeset = PostCommands.changeset
+        render conn, "new.html", changeset: changeset, thread: thread_id
+    end
+
+    def create(conn, %{"thread_id" => thread_id, "post" => post_params}) do
+        thread = ThreadCommands.find!(thread_id)
+
+        case PostCommands.create(thread, post_params) do
+            {:ok, _post} ->
+                conn
+                |> put_flash(:info, "Successfully posted!")
+                |> redirect(to: thread_post_path(conn, :index, thread))
+            {:error, changeset} ->
+                conn
+                |> put_flash(:error, "An error has occured while creating your post")
+                |> render("new.html", changeset: changeset, thread: thread)
+        end
+    end
+
+    def edit(conn, %{"thread_id" => thread_id, "id" => post_id}) do
+        post      = PostCommands.find(post_id)
+        changeset = PostCommands.changeset(post)
+
+        render conn, "edit.html", changeset: changeset, post: post, thread: thread_id
+    end
+
+    def update(conn, %{"thread_id" => thread_id, "id" => post_id,  "post" => post}) do
+        case PostCommands.update(post_id, post) do
+            {:ok, _post} ->
+                conn
+                |> put_flash(:info, "Successfully updated your post")
+                |> redirect(to: thread_post_path(conn, :index, thread_id))
+            {:error, changeset} ->
+                conn
+                |> put_flash(:error, "There was an error with editing this post")
+                |> render("edit.html", changeset: changeset, thread: thread_id)
+        end
+    end
+
+    def delete(conn, %{"thread_id" => thread_id, "id" => post_id}) do
+        PostCommands.delete!(post_id)
+
+        conn
+        |> put_flash(:info, "Successfully deleted the post")
+        |> redirect(to: thread_post_path(conn, :index, thread_id))
+    end
+end

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/thread_controller.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/thread_controller.ex
@@ -12,7 +12,7 @@ defmodule MockForum.Web.ThreadController do
     end
 
     def show(conn, %{"subject_id" => subject_id, "id" => thread_id}) do
-        render conn, "show.html", subject: subject_id, thread: ThreadCommands.find!(thread_id)
+        redirect(conn, to: thread_post_path(conn, :index, thread_id))
     end
 
     def new(conn, %{"subject_id" => subject_id}) do
@@ -47,11 +47,11 @@ defmodule MockForum.Web.ThreadController do
         case ThreadCommands.update(thread_id, thread) do
             {:ok, _thread} ->
                 conn
-                |> put_flash(:info, "successfully edited the subject")
-                |> redirect(to: thread_path(conn, :show, subject_id, thread_id))
+                |> put_flash(:info, "successfully edited the thread")
+                |> redirect(to: subject_thread_path(conn, :show, subject_id, thread_id))
             {:error, changeset} ->
                 conn
-                |> put_flash(:error, "There was an error with editing this subject")
+                |> put_flash(:error, "There was an error with editing this thread")
                 |> render("edit.html", changeset: changeset, subject: subject_id)
         end
     end
@@ -60,7 +60,7 @@ defmodule MockForum.Web.ThreadController do
         ThreadCommands.delete!(thread_id)
 
         conn
-        |> put_flash(:info, "Successfully deleted the subject")
+        |> put_flash(:info, "Successfully deleted the thread")
         |> redirect(to: subject_path(conn, :show, subject_id))
     end
 end

--- a/apps/mock_forum_web/lib/mock_forum_web/router.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/router.ex
@@ -18,12 +18,14 @@ defmodule MockForum.Web.Router do
     pipe_through :browser # Use the default browser stack
 
     get "/", PageController, :index
-    resources "/subject", SubjectController
+    resources "/subject", SubjectController do
+          resources "/thread", ThreadController
+    end
   end
 
-  scope "/subject/:subject_id", MockForum.Web do
+  scope "/thread/:thread_id", MockForum.Web, as: :thread do
     pipe_through :browser
-    resources "/thread", ThreadController
+    resources "/post", PostController
   end
 
   scope "/auth", MockForum.Web do

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/post/_form.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/post/_form.html.eex
@@ -1,0 +1,6 @@
+<div class="form-group">
+    <%= textarea @f, :message, placeholder: "Message", class: "form-control" %>
+    <%= error_tag @f, :message %>
+
+    <%= submit "Submit", class: "btn btn-primary" %>
+</div>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/post/edit.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/post/edit.html.eex
@@ -1,0 +1,3 @@
+<%= form_for @changeset, thread_post_path(@conn, :update, @thread, @post), fn f -> %>
+    <%= render MockForum.Web.PostView, "_form.html", f: f %>
+<% end %>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/post/index.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/post/index.html.eex
@@ -1,0 +1,15 @@
+<h2>All posts are to be listed here</h2>
+<%= link("New post", to: thread_post_path(@conn, :new, @thread)) %> 
+
+
+<ul class="list-group">
+            <%= for post <- @posts do %>
+                <li class="list-group-item"> 
+                    <%= post.message %>
+                    <span class="nav navbar-nav navbar-right">
+                        <%= link("Edit", to: thread_post_path(@conn, :edit, @thread, post), class: "btn btn-primary") %>
+                        <%= link("Destroy", to: thread_post_path(@conn, :delete, @thread, post), method: :delete, class: "btn btn-danger") %>
+                    </span>
+                </li>
+            <% end %>
+</ul>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/post/new.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/post/new.html.eex
@@ -1,0 +1,3 @@
+<%= form_for @changeset, thread_post_path(@conn, :create, @thread), fn f -> %>
+    <%= render MockForum.Web.PostView, "_form.html", f: f %>
+<% end %>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/subject/show.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/subject/show.html.eex
@@ -2,13 +2,13 @@
 <%= link("Edit", to: subject_path(@conn, :edit, @subject), class: "btn btn-primary") %>
 
 <br/><br/>
-<%= link("New Thread", to: thread_path(@conn, :new, @subject.id)) %>
+<%= link("New Thread", to: subject_thread_path(@conn, :new, @subject.id)) %>
 <br/><br/>
 
 <%= for thread <- @subject.threads do %>
 <ul>
     <li>
-        <%= link(thread.title, to: thread_path(@conn, :show, @subject, thread)) %>
+        <%= link(thread.title, to: thread_post_path(@conn, :index, thread)) %>
     </li>
 </ul>
 <% end %>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/thread/edit.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/thread/edit.html.eex
@@ -1,3 +1,3 @@
-<%= form_for @changeset, thread_path(@conn, :update, @subject, @thread), fn f -> %>
+<%= form_for @changeset, subject_thread_path(@conn, :update, @subject, @thread), fn f -> %>
     <%= render MockForum.Web.ThreadView, "_form.html", f: f %>
 <% end %>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/thread/new.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/thread/new.html.eex
@@ -1,3 +1,3 @@
-<%= form_for @changeset, thread_path(@conn, :create, @subject), fn f -> %>
+<%= form_for @changeset, subject_thread_path(@conn, :create, @subject), fn f -> %>
     <%= render MockForum.Web.ThreadView, "_form.html", f: f %>
 <% end %>

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/thread/show.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/thread/show.html.eex
@@ -1,3 +1,3 @@
-<h1><%= @thread.title %></h1> <%= link("Edit Title", to: thread_path(@conn, :edit, @subject, @thread), class: "btn btn-primary") %>
+<h1><%= @thread.title %></h1> <%= link("Edit Title", to: subject_thread_path(@conn, :edit, @subject, @thread), class: "btn btn-primary") %>
 
-<%= link("Delete Thread", to: thread_path(@conn, :delete, @subject, @thread), method: :delete, class: "btn btn-primary") %>
+<%= link("Delete Thread", to: subject_thread_path(@conn, :delete, @subject, @thread), method: :delete, class: "btn btn-primary") %>

--- a/apps/mock_forum_web/lib/mock_forum_web/views/post_view.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/views/post_view.ex
@@ -1,0 +1,3 @@
+defmodule MockForum.Web.PostView do
+  use MockForum.Web, :view
+end

--- a/apps/mock_forum_web/test/factories/post_factory.ex
+++ b/apps/mock_forum_web/test/factories/post_factory.ex
@@ -1,0 +1,13 @@
+defmodule MockForum.Web.PostFactory do
+    @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def post_factory do
+        %MockForum.Post{
+          message: "My awesome message",
+          thread: build(:thread)
+        }
+      end
+    end
+  end
+end

--- a/apps/mock_forum_web/test/mock_forum_web/feature/post_feature_test.exs
+++ b/apps/mock_forum_web/test/mock_forum_web/feature/post_feature_test.exs
@@ -1,0 +1,20 @@
+defmodule MockForum.Web.Feature.PostFeatureTest do
+  use MockForum.Web.FeatureCase, async: true
+
+  import MockForum.Web.Factory
+  import Wallaby.Query, only: [text_field: 1, link: 1, button: 1, css: 2]
+
+  describe "Creating a new post" do
+    test "A User can create a non-blank post message for a thread", %{session: session} do
+        thread = insert(:thread)
+        session
+        |> visit("/thread/#{thread.id}/post")
+        |> click(link("New post"))
+        |> click(button("Submit"))
+        |> assert_has(css(".help-block", text: "can't be blank"))
+        |> fill_in(text_field("post_message"), with: "Here is my post")
+        |> click(button("Submit"))
+        |> assert_has(css(".list-group-item", text: "Here is my post"))
+    end
+  end
+end

--- a/apps/mock_forum_web/test/mock_forum_web/feature/threads_feature_test.exs
+++ b/apps/mock_forum_web/test/mock_forum_web/feature/threads_feature_test.exs
@@ -1,22 +1,10 @@
 defmodule MockForum.Web.Feature.ThreadFeatureTest do
-    import MockForum.Web.Router.Helpers
-
   use MockForum.Web.FeatureCase, async: true
 
   import MockForum.Web.Factory
   import Wallaby.Query, only: [text_field: 1, link: 1, button: 1, css: 2]
 
   describe "Creating a new thread" do
-    test "User can create a new thread and view it", %{session: session} do
-        subject = insert(:subject)
-        session
-        |> visit("/subject/#{subject.id}")
-        |> click(link("New Thread"))
-        |> fill_in(text_field("thread_title"), with: "Here is my thread name")
-        |> click(button("Submit"))
-        |> assert_has(link("Here is my thread name"))
-    end
-
     test "A thread name cannot be blank", %{session: session} do
         subject = insert(:subject)
         session
@@ -24,6 +12,9 @@ defmodule MockForum.Web.Feature.ThreadFeatureTest do
         |> click(link("New Thread"))
         |> click(button("Submit"))
         |> assert_has(css(".help-block", text: "can't be blank"))
+        |> fill_in(text_field("thread_title"), with: "Here is my thread name")
+        |> click(button("Submit"))
+        |> assert_has(link("Here is my thread name"))
     end
   end
 
@@ -33,7 +24,7 @@ defmodule MockForum.Web.Feature.ThreadFeatureTest do
       session
       |> visit("/subject/#{thread.subject_id}")
       |> click(link(thread.title))
-      |> assert_has(link("Delete Thread"))
+      |> assert_has(link("New post"))
     end
   end
 end

--- a/apps/mock_forum_web/test/support/factories.ex
+++ b/apps/mock_forum_web/test/support/factories.ex
@@ -4,4 +4,5 @@ defmodule MockForum.Web.Factory do
   use ExMachina.Ecto, repo: MockForum.Repo
   use MockForum.Web.SubjectFactory
   use MockForum.Web.ThreadFactory
+  use MockForum.Web.PostFactory
 end

--- a/apps/mock_forum_web/test/test_helper.exs
+++ b/apps/mock_forum_web/test/test_helper.exs
@@ -5,11 +5,11 @@ Ecto.Adapters.SQL.Sandbox.mode(MockForum.Repo, :manual)
 {:ok, _} = Application.ensure_all_started(:wallaby)
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 
+# Remove past screenshots
+File.rm_rf("../../tmp/screenshots")
+
 Application.put_env(:wallaby, :base_url, MockForum.Web.Endpoint.url)
 Application.put_env(:wallaby, :screenshot_dir, "../../tmp/screenshots")
 Application.put_env(:wallaby, :screenshot_on_failure, true)
-
-# Remove past screenshots
-File.rm_rf("../../tmp/screenshots")
 
 


### PR DESCRIPTION
- Router paths fixed for Subject & Thread
- Fixed flash message wording
- Added a new relation to Thread. `Thread <= Post`
- Post's can be CRUD'd for a given thread