### PR TITLE
Assign users to their created posts

### DIFF
--- a/apps/mock_forum/lib/mock_forum/commands/post_commands.ex
+++ b/apps/mock_forum/lib/mock_forum/commands/post_commands.ex
@@ -8,7 +8,12 @@ defmodule MockForum.Commands.PostCommands do
         record_type: Post, 
         associations: []
 
-    def create(thread, thread_params) do
-        thread |> build_assoc(:posts) |> changeset(thread_params) |> Repo.insert
+    def create(thread, user, post_params) do
+     %Post{} 
+        |> changeset(post_params) 
+        |> change
+        |> put_assoc(:user, user, required: true)
+        |> put_assoc(:thread, thread, required: true)
+        |> Repo.insert
     end
 end

--- a/apps/mock_forum/lib/mock_forum/commands/thread_commands.ex
+++ b/apps/mock_forum/lib/mock_forum/commands/thread_commands.ex
@@ -6,16 +6,31 @@ defmodule MockForum.Commands.ThreadCommands do
     use MockForum.Commands.CrudCommands, 
         record_schema:  %Thread{}, 
         record_type: Thread, 
-        associations: [:posts]
+        associations: [posts: :user]
 
     alias MockForum.Commands.PostCommands
 
-    def new_thread(record \\ %Thread{}, record_params \\ %{}) do
+    def new_thread(record_params \\ %{}) do
         post = PostCommands.changeset
-        changeset(%Thread{posts: [post]})
+        changeset(%Thread{posts: [post]}, record_params)
     end
 
-    def create(subject, thread_params) do
-        subject |> build_assoc(:threads) |> changeset(thread_params) |> Repo.insert
+    def create(subject, user, thread_params) do
+        thread_params = assign_user(thread_params, user)
+
+        subject 
+        |> build_assoc(:threads) 
+        |> changeset(thread_params) 
+        |> Repo.insert
+    end
+
+
+    # This is a very dirty method for assign the user to the new thread's inital post
+    # I am looking for a more cleaner method to fix this nested struct mess!
+
+    defp assign_user(params, user) do
+        set_user = Map.put(params["posts"]["0"], "user_id", user.id)
+        set_post = Map.put(params["posts"], "0", set_user)
+        Map.put(params, "posts", set_post)
     end
 end

--- a/apps/mock_forum/lib/mock_forum/schema/post.ex
+++ b/apps/mock_forum/lib/mock_forum/schema/post.ex
@@ -5,6 +5,7 @@ defmodule MockForum.Post do
 
     schema "posts" do
         belongs_to :thread, MockForum.Thread
+        belongs_to :user, MockForum.User
         field :message, :string
 
         timestamps()
@@ -12,8 +13,9 @@ defmodule MockForum.Post do
 
     def changeset(struct, params \\ %{}) do
         struct
-        |> cast(params, [:message, :thread_id])
+        |> cast(params, [:message, :user_id, :thread_id])
         |> cast_assoc(:thread)
+        |> cast_assoc(:user)
         |> validate_required([:message])
     end
 end

--- a/apps/mock_forum/lib/mock_forum/schema/user.ex
+++ b/apps/mock_forum/lib/mock_forum/schema/user.ex
@@ -9,6 +9,8 @@ defmodule MockForum.User do
         field :email, :string
         field :token, :string
         field :provider, :string
+        
+        has_many :posts, MockForum.Post, on_delete: :delete_all
 
         timestamps()
     end

--- a/apps/mock_forum/priv/repo/migrations/20170625140553_add_user_to_post.exs
+++ b/apps/mock_forum/priv/repo/migrations/20170625140553_add_user_to_post.exs
@@ -1,0 +1,9 @@
+defmodule MockForum.Repo.Migrations.AddUserToPost do
+  use Ecto.Migration
+
+  def change do
+    alter table(:posts) do
+      add :user_id, references(:users)
+    end
+  end
+end

--- a/apps/mock_forum_web/assets/css/app.css
+++ b/apps/mock_forum_web/assets/css/app.css
@@ -416,6 +416,7 @@
 	#wrapper
 	{
 		background: #FFF;
+		padding-bottom: 140px;
 	}
 	
 	#page

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/auth_controller.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/auth_controller.ex
@@ -22,7 +22,7 @@ defmodule MockForum.Web.AuthController do
         changeset = User.changeset(%User{}, user_params)
         signin(conn, changeset)
     end
-    
+
     def signout(conn, _params) do
         conn
         |> configure_session(drop: true)

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/page_controller.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/page_controller.ex
@@ -1,8 +1,6 @@
 defmodule MockForum.Web.PageController do
   use MockForum.Web, :controller
 
-  # plug MockForum.Web.Plugs.RequireAuth when action in [:create]
-
   alias MockForum.Commands.SubjectCommands
 
   def index(conn, _params) do

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/plugs/requre_auth.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/plugs/requre_auth.ex
@@ -1,15 +1,15 @@
 defmodule MockForum.Web.Plugs.RequireAuth do
     @moduledoc """
-        Checks to see if the user has been assigned to the connection. 
+        Checks to see if the user has been assigned to the connection.
         If not, it will redirect back to the root page with an error message.
     """
     import Plug.Conn
     import Phoenix.Controller
 
-    alias MockForum.Router.Helpers
+    alias MockForum.Web.Router.Helpers
 
     def init(_params) do
-        
+
     end
 
     def call(conn, _params) do
@@ -22,5 +22,5 @@ defmodule MockForum.Web.Plugs.RequireAuth do
             |> halt()
         end
     end
-    
+
 end

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/plugs/set_user.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/plugs/set_user.ex
@@ -1,6 +1,6 @@
 defmodule MockForum.Web.Plugs.SetUser do
     @moduledoc """
-        Once the user has signin, assign the user object to the connection. 
+        Once the user has signin, assign the user object to the connection.
         Otherwise set it to nil if no user is signed in.
     """
     import Plug.Conn
@@ -14,8 +14,16 @@ defmodule MockForum.Web.Plugs.SetUser do
 
     # Assigns the user object to connection if the user has signed in
     def call(conn, _params) do
-        user_id = get_session(conn, :user_id)
+        user_id = fetch_user_id(conn)
         user    = if user_id, do: Repo.get(User, user_id), else: nil
         assign(conn, :user, user)
+    end
+
+    defp fetch_user_id(conn) do
+        if Mix.env == :test do
+            conn.cookies["user_id"]
+        else
+            get_session(conn, :user_id)
+        end
     end
 end

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/post_controller.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/post_controller.ex
@@ -4,6 +4,7 @@ defmodule MockForum.Web.PostController do
     """
 
     use MockForum.Web, :controller
+    plug MockForum.Web.Plugs.RequireAuth when action in [:new, :create, :edit, :update]
     
     alias MockForum.Commands.{ThreadCommands, PostCommands}
 
@@ -20,8 +21,7 @@ defmodule MockForum.Web.PostController do
 
     def create(conn, %{"thread_id" => thread_id, "post" => post_params}) do
         thread = ThreadCommands.find!(thread_id)
-
-        case PostCommands.create(thread, post_params) do
+        case PostCommands.create(thread, conn.assigns[:user], post_params) do
             {:ok, _post} ->
                 conn
                 |> put_flash(:info, "Successfully posted!")

--- a/apps/mock_forum_web/lib/mock_forum_web/controllers/thread_controller.ex
+++ b/apps/mock_forum_web/lib/mock_forum_web/controllers/thread_controller.ex
@@ -4,8 +4,10 @@ defmodule MockForum.Web.ThreadController do
     """
 
     use MockForum.Web, :controller
+
+    plug MockForum.Web.Plugs.RequireAuth when action in [:new, :create, :edit, :update]
     
-    alias MockForum.Commands.{ThreadCommands, SubjectCommands, PostCommands}
+    alias MockForum.Commands.{ThreadCommands, SubjectCommands}
 
     def index(conn, _params) do
         render conn, "index.html", subjects: ThreadCommands.all
@@ -24,7 +26,7 @@ defmodule MockForum.Web.ThreadController do
     def create(conn, %{"subject_id" => subject_id, "thread" => thread_params}) do
         subject = SubjectCommands.find(subject_id)
 
-        case ThreadCommands.create(subject, thread_params) do
+        case ThreadCommands.create(subject, conn.assigns.user, thread_params) do
             {:ok, _thread} ->
                 conn
                 |> put_flash(:info, "successfully created a new thread")

--- a/apps/mock_forum_web/lib/mock_forum_web/templates/post/index.html.eex
+++ b/apps/mock_forum_web/lib/mock_forum_web/templates/post/index.html.eex
@@ -10,7 +10,7 @@
         <div class="timeline-badge"><i class="glyphicon glyphicon-check"></i></div>
         <div class="timeline-panel">
           <div class="timeline-heading">
-            <h4 class="timeline-title">USER NAME GOES HERE</h4>
+            <h4 class="timeline-title"> <%= post.user.first_name %> </h4>
             <p><small class="text-muted"><i class="glyphicon glyphicon-time"></i> 11 hours ago via Twitter</small></p>
           </div>
           <div class="timeline-body">

--- a/apps/mock_forum_web/test/factories/user_factory.ex
+++ b/apps/mock_forum_web/test/factories/user_factory.ex
@@ -1,0 +1,16 @@
+defmodule MockForum.Web.UserFactory do
+    @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def user_factory do
+        %MockForum.User{
+          first_name: "Example",
+          last_name: "User",
+          email: "user@example.com",
+          token: "ABC123",
+          provider: "github"
+        }
+      end
+    end
+  end
+end

--- a/apps/mock_forum_web/test/mock_forum_web/feature/post_feature_test.exs
+++ b/apps/mock_forum_web/test/mock_forum_web/feature/post_feature_test.exs
@@ -1,14 +1,43 @@
 defmodule MockForum.Web.Feature.PostFeatureTest do
   use MockForum.Web.FeatureCase, async: true
+  use Plug.Test
+
+  alias Plug.Conn
 
   import MockForum.Web.Factory
   import Wallaby.Query, only: [text_field: 1, link: 1, button: 1, css: 2]
 
+  @session Plug.Session.init(
+    store: :cookie,
+    key: "_app",
+    encryption_salt: "yadayada",
+    signing_salt: "yadayada"
+  )
+
+  #   setup do
+  #     user = insert(:user)
+  #     session_data = %{user_id: user.id}
+
+  #     conn =
+  #       conn(:get, "/")
+  #       |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
+  #       |> Plug.Session.call(@session)
+  #       |> Conn.fetch_session()
+  #     {:ok, conn: conn, user: user, session_data: session_data}
+  # end
+
   describe "Creating a new post" do
     test "A User can create a non-blank post message for a thread", %{session: session} do
         thread = insert(:thread)
+        user = insert(:user)
+
+        IO.puts "ZZZZZZZZZZZZZZ"
+        IO.inspect session
+        IO.puts "ZZZZZZZZZZZZZZ"
+
         session
         |> visit("/thread/#{thread.id}/post")
+        |> take_screenshot
         |> click(link("New post"))
         |> click(button("Submit"))
         |> assert_has(css(".help-block", text: "can't be blank"))

--- a/apps/mock_forum_web/test/mock_forum_web/feature/post_feature_test.exs
+++ b/apps/mock_forum_web/test/mock_forum_web/feature/post_feature_test.exs
@@ -1,43 +1,25 @@
 defmodule MockForum.Web.Feature.PostFeatureTest do
   use MockForum.Web.FeatureCase, async: true
-  use Plug.Test
-
-  alias Plug.Conn
 
   import MockForum.Web.Factory
   import Wallaby.Query, only: [text_field: 1, link: 1, button: 1, css: 2]
 
-  @session Plug.Session.init(
-    store: :cookie,
-    key: "_app",
-    encryption_salt: "yadayada",
-    signing_salt: "yadayada"
-  )
+ setup %{session: session} do
+    user = insert(:user)
 
-  #   setup do
-  #     user = insert(:user)
-  #     session_data = %{user_id: user.id}
+    session
+    |> visit("/")
+    |> set_cookie("user_id", user.id)
 
-  #     conn =
-  #       conn(:get, "/")
-  #       |> Map.put(:secret_key_base, String.duplicate("abcdefgh", 8))
-  #       |> Plug.Session.call(@session)
-  #       |> Conn.fetch_session()
-  #     {:ok, conn: conn, user: user, session_data: session_data}
-  # end
+    {:ok, session: session, user: user}
+  end
 
   describe "Creating a new post" do
     test "A User can create a non-blank post message for a thread", %{session: session} do
         thread = insert(:thread)
-        user = insert(:user)
-
-        IO.puts "ZZZZZZZZZZZZZZ"
-        IO.inspect session
-        IO.puts "ZZZZZZZZZZZZZZ"
 
         session
         |> visit("/thread/#{thread.id}/post")
-        |> take_screenshot
         |> click(link("New post"))
         |> click(button("Submit"))
         |> assert_has(css(".help-block", text: "can't be blank"))

--- a/apps/mock_forum_web/test/mock_forum_web/feature/subject_feature_test.exs
+++ b/apps/mock_forum_web/test/mock_forum_web/feature/subject_feature_test.exs
@@ -4,6 +4,16 @@ defmodule MockForum.Web.Feature.SubjectFeatureTest do
   import MockForum.Web.Factory
   import Wallaby.Query, only: [text_field: 1, link: 1, button: 1, css: 2]
 
+   setup %{session: session} do
+    user = insert(:user)
+
+    session
+    |> visit("/")
+    |> set_cookie("user_id", user.id)
+
+    {:ok, session: session, user: user}
+  end
+
   describe "Creating a new subject" do
     test "User can create a new subject and view it", %{session: session} do
       session

--- a/apps/mock_forum_web/test/mock_forum_web/feature/threads_feature_test.exs
+++ b/apps/mock_forum_web/test/mock_forum_web/feature/threads_feature_test.exs
@@ -4,9 +4,20 @@ defmodule MockForum.Web.Feature.ThreadFeatureTest do
   import MockForum.Web.Factory
   import Wallaby.Query, only: [text_field: 1, link: 1, button: 1, css: 2]
 
+  setup %{session: session} do
+    user = insert(:user)
+
+    session
+    |> visit("/")
+    |> set_cookie("user_id", user.id)
+
+    {:ok, session: session, user: user}
+  end
+
   describe "Creating a new thread" do
     test "A thread name cannot be blank", %{session: session} do
         subject = insert(:subject)
+
         session
         |> visit("/subject/#{subject.id}")
         |> click(link("New Thread"))

--- a/apps/mock_forum_web/test/support/factories.ex
+++ b/apps/mock_forum_web/test/support/factories.ex
@@ -5,4 +5,5 @@ defmodule MockForum.Web.Factory do
   use MockForum.Web.SubjectFactory
   use MockForum.Web.ThreadFactory
   use MockForum.Web.PostFactory
+  use MockForum.Web.UserFactory
 end


### PR DESCRIPTION
- Assigns the user to the post they have created
- Creates posts in a nested state
- Enforces authentication on parts
- Specs have been updated to ensure the user is already signed in